### PR TITLE
Update GeetestController.php

### DIFF
--- a/src/GeetestController.php
+++ b/src/GeetestController.php
@@ -7,4 +7,8 @@ use Illuminate\Routing\Controller;
 class GeetestController extends Controller
 {
 	use GeetestCaptcha;
+	public function __construct()
+	{
+		$this->middleware('web');
+	}
 }


### PR DESCRIPTION
如果不使用 web middleware
session 就没有启动
session 如果没有启动，设置的 gtserver 为 1 在下一个页面读 session 就是 null
读到 null 了就会跳到本地认证，而实际上又是服务端验证
使用 failback 就验证失败了……
于是就整个莫名不好使

不过其实在 Provider 的 Router 上加也是可以的